### PR TITLE
Issue #7 Ping Pong UDP

### DIFF
--- a/sockets/latency/Makefile
+++ b/sockets/latency/Makefile
@@ -4,10 +4,16 @@ default:
 clean:
 	-rm latency-count
 
-test:
-	./latency-count -m server -p 1234 &
+test test_tcp:
+	./latency-count -m server -p 1234 -s tcp &
 	sleep 1
-	./latency-count -m client -h 127.0.0.1 -p 1234 -n 100
+	./latency-count -m client -h 127.0.0.1 -p 1234 -n 10000 -s tcp
 	sleep 1
 	-killall latency-count
 
+test_udp:
+	./latency-count -m server -p 1234 -s udp &
+	sleep 1
+	./latency-count -m client -h 127.0.0.1 -p 1234 -n 10000 -s udp
+	sleep 1
+	-killall latency-count

--- a/sockets/latency/README
+++ b/sockets/latency/README
@@ -5,11 +5,14 @@ Installation
 
 Usage
 
-Step one: run it in a server
-        ./latency-count -m server -p [port]
+Step one: run it in a server.  Protocol can be any cased substring of TCP/UDP.
+        ./latency-count -m server -p [port] -s [protocol]
 
-Step two: test and get the result in a client
-        ./latency-count -m client -h [server_ip] -p [port] -n [times]
+Step two: test and get the result in a client.  The Protocol has to be the same as that of the client.
+        ./latency-count -m client -h [server_ip] -p [port] -n [times] -s [protocol]
 
-Special: test in the same machine by default
-        make test
+Special one: test tcp in the same machine by default
+        make test_tcp
+
+Special two: test udp in the same machine by default
+	make test_udp

--- a/sockets/latency/latency-count.c
+++ b/sockets/latency/latency-count.c
@@ -10,7 +10,7 @@
 #include <sys/time.h>
 
 /****************************************
-        Author: Chenghu He, Tim Wood
+        Author: Chenghu He, Tim Wood, Anthony Korzan
         Code based on client-tcp.c and server-tcp.c
         http://beej.us/guide/bgnet/
 ****************************************/
@@ -18,9 +18,9 @@
 #define BACKLOG 10     // how many pending connections queue will hold
 
 /*
-        The server_loop works as a server, handle requests and sends the count numbers back
+        server_loop_tcp works as a server using TCP, handles requests, and sends the count numbers back
 */
-int server_loop(char *server_port) 
+int server_loop_tcp(char *server_port) 
 {
         int sockfd, rc;
         int yes = 1;
@@ -86,7 +86,7 @@ int server_loop(char *server_port)
                         }
                 }
 
-                printf("Connection droped!\n");
+                printf("Connection dropped!\n");
                 close(clientfd);
         }
 
@@ -96,10 +96,85 @@ int server_loop(char *server_port)
 }
 
 /*
-        The client_count works for generate count numbers and sends them to the server, 
+        server_loop_udp listens to udp connections, handles requests, and sends the count numbers back
+*/
+int server_loop_udp(char *server_port) 
+{
+        int sockfd, rc;
+        int yes = 1;
+        struct addrinfo hints, *server;
+        char message[256];
+
+        /* The hints struct is used to specify what kind of server info we are looking for */
+        memset(&hints, 0, sizeof hints);
+        hints.ai_family = AF_INET;
+        hints.ai_socktype = SOCK_DGRAM;
+        hints.ai_flags = AI_PASSIVE;
+
+        /* getaddrinfo() gives us back a server address we can connect to.
+           The first parameter is NULL since we want an address on this host.
+           It actually gives us a linked list of addresses, but we'll just use the first.
+         */
+        if ((rc = getaddrinfo(NULL, server_port, &hints, &server)) != 0) {
+                perror(gai_strerror(rc));
+                exit(-1);
+        }
+
+        /* Now we can create the socket and bind it to the local IP and port */
+        sockfd = socket(server->ai_family, server->ai_socktype, server->ai_protocol);
+        if (sockfd == -1) {
+                perror("ERROR opening socket");
+                exit(-1);
+        }
+        /* Get rid of "Address already in use" error messages */
+        if (setsockopt(sockfd, SOL_SOCKET, SO_REUSEADDR, &yes, sizeof(int)) == -1) {
+                perror("setsockopt");
+                exit(-1);
+        }
+        rc = bind(sockfd, server->ai_addr, server->ai_addrlen);
+        if (rc == -1) {
+                perror("ERROR on connect");
+                close(sockfd);
+                exit(-1);
+                // TODO: could use goto here for error cleanup
+        }
+
+        /* Loop forever accepting new connections. */
+        while(1) {
+                struct sockaddr_storage client_addr;
+                socklen_t addr_size;
+                int clientfd;
+                int bytes_read, bytes_write;
+
+                addr_size = sizeof client_addr;
+
+                /* Use a loop to receive couters and reply them */
+                while (1) {
+                        bytes_read = recvfrom(sockfd, message, sizeof message, MSG_WAITALL, (struct sockaddr *)&client_addr, &addr_size); 
+                        if(bytes_read < 0) {
+                                perror("ERROR reading socket");
+                        }
+                        if (bytes_read == 0) break;
+                        bytes_write = sendto(sockfd, (char *)&message, bytes_read, 0, (struct sockaddr *)&client_addr, addr_size);
+                        if(bytes_write < 0) {
+                                perror("ERROR writing socket");
+                        }
+                }
+
+                printf("Connection dropped!\n");
+                close(clientfd);
+        }
+
+        freeaddrinfo(server);
+        close(sockfd);
+        return 0;
+}
+
+/*
+        Client_count_tcp works to generate count numbers and sends them to the server, 
         reveives the send-back numbers, and calculates the min, max, and average delay
 */
-int client_count(char *server_ip, char *server_port, char *number_input)
+int client_count_tcp(char *server_ip, char *server_port, char *number_input)
 {
         int sockfd, rc;
         struct addrinfo hints, *server;
@@ -153,9 +228,95 @@ int client_count(char *server_ip, char *server_port, char *number_input)
                         perror("ERROR on send");
                         exit(-1);
                 }
+
                 rc = recv(sockfd, (char *)&re_counter, sizeof re_counter, 0);
                 if(rc < 0) {
                         perror("ERROR on recv");
+                        exit(-1);
+                }
+
+                /* End of the time calculation */
+                gettimeofday(&tval_end, NULL);
+
+                /* Calculation */
+                diff = (tval_end.tv_sec - tval_start.tv_sec) * 1000000LL + tval_end.tv_usec - tval_start.tv_usec;
+                if (min == -1LL || diff < min) min = diff;  
+                if (max == -1LL || diff > max) max = diff;
+                avg = avg * (counter - 1) / counter + (long double)diff / counter ;
+                counter++;
+        }
+
+        /* Show the result */
+        printf("Result:\n");
+        printf("        The total number of loops   : %d\n", number_try);
+        printf("        The min time of latency     : %lld us\n", min);
+        printf("        The max time of latency     : %lld us\n", max);
+        printf("        The average time of latency : %Lf us\n", avg);
+
+        freeaddrinfo(server);
+        close(sockfd);
+        return 0;
+}
+
+/*
+        Same functionality as client_count_tcp but uses UDP and measures dropped pockets.
+*/
+int client_count_udp(char *server_ip, char *server_port, char *number_input)
+{
+        int sockfd, rc;
+        struct addrinfo hints, *server;
+        int number_try, counter = 1, re_counter;
+        struct timeval tval_start, tval_end;
+        long long int diff, min = -1LL, max = -1LL;
+        long double avg = 0.0L;
+
+        /* Get the number from string number_input and check the result */
+        number_try = atoi(number_input);
+        if (number_try < 1) {
+                printf("Invalid number input, number of connections resets to 100\n");
+                number_try = 100;
+        }        
+
+        /* The hints struct is used to specify what kind of server info we are looking for */
+        memset(&hints, 0, sizeof hints);
+        hints.ai_family = AF_INET;
+        hints.ai_socktype = SOCK_DGRAM;
+
+        /* getaddrinfo() gives us back a server address we can connect to.
+           It actually gives us a linked list of addresses, but we'll just use the first.
+         */
+        if ((rc = getaddrinfo(server_ip, server_port, &hints, &server)) != 0) {
+                perror(gai_strerror(rc));
+                exit(-1);
+        }
+
+        /* Now we can create the socket and connect */
+        sockfd = socket(server->ai_family, server->ai_socktype, server->ai_protocol);
+        if (sockfd == -1) {
+                perror("ERROR opening socket");
+                exit(-1);
+        }
+
+        /* Send the message with a loop */
+        while (counter <= number_try) {
+                /* We will need to allow the server to reach us back by UDP,
+                   and this is where we store the server's info connecting as a client to us. */
+                struct sockaddr_storage client_addr;
+                socklen_t addr_size = sizeof client_addr;
+                /* Start of the time calculation */
+                gettimeofday(&tval_start, NULL);
+
+                /* Sendto using UDP as specified in sockfd by server->ai_protocol */
+                rc = sendto(sockfd, (char *)&counter, sizeof counter, 0, server->ai_addr, server->ai_addrlen);
+                if(rc < 0) {
+                        perror("ERROR on sendto");
+                        exit(-1);
+                }
+
+                /* Set to flag MSG_WAITALL for blocking the loop of receiving */
+                rc = recvfrom(sockfd, (char *)&re_counter, sizeof re_counter, MSG_WAITALL, (struct sockaddr *)&client_addr, &addr_size);
+                if(rc < 0) {
+                        perror("ERROR on recvfrom");
                         exit(-1);
                 }
 
@@ -191,6 +352,7 @@ int main(int argc, char ** argv)
         char *server_port = "1234";
         char *server_ip = "127.0.0.1";
         char *number_input = "100";
+        char protocol = 't';
         int o;
 
         /* Command line args:
@@ -198,8 +360,9 @@ int main(int argc, char ** argv)
                 -m mode client or server
                 -p port
                 -h host name or IP
+                -s socket (UDP or TCP)
         */
-        while ((o = getopt (argc, argv, "p:h:m:n:")) != -1) {
+        while ((o = getopt (argc, argv, "p:h:m:n:s:")) != -1) {
                 switch(o){
                 case 'p':
                         server_port = optarg;
@@ -212,6 +375,15 @@ int main(int argc, char ** argv)
                         break;
                 case 'n':
                         number_input = optarg;
+                        break;
+                case 's':
+                        if (optarg[0] == 'T' || optarg[0] == 't') {
+                                protocol = 't';
+                        } else if (optarg[0] == 'U' || optarg[0] == 'u') {
+                                protocol = 'u';
+                        } else {
+                                fprintf (stderr, "Option %c accepts either TCP or UDP\n", optopt);
+                        }
                         break;
                 case '?':
                         if(optopt == 'm' || optopt == 'p' || optopt == 'h' ) {
@@ -229,7 +401,16 @@ int main(int argc, char ** argv)
                 if (strncmp(mode, "server", 6) == 0) {
                         printf("LatencyCount[%d] works on server mode!\n", getpid());
                         printf("        Local Server Port : %s\n", server_port);
-                        server_loop(server_port);
+                        switch (protocol) {
+                        case 't': // TCP
+                                printf("        Server's Protocol : TCP\n");
+                                server_loop_tcp(server_port);
+                                break;
+                        case 'u': // UDP
+                                printf("        Server's Protocol : UDP\n");
+                                server_loop_udp(server_port);
+                                break;
+                        }
                         return 0;
                 }
                 else if (strncmp(mode, "client", 6) == 0) {
@@ -237,7 +418,16 @@ int main(int argc, char ** argv)
                         printf("        Remote Server IP  : %s\n", server_ip);
                         printf("        Remote Server Port: %s\n", server_port);
                         printf("        Connecting Times  : %s\n", number_input);
-                        client_count(server_ip, server_port, number_input);
+                        switch (protocol) {
+                        case 't': // TCP
+                                printf("        Client's Protocol : TCP\n");
+                                client_count_tcp(server_ip, server_port, number_input);
+                                break;
+                        case 'u': // UDP
+                                printf("        Client's Protocol : UDP\n");
+                                client_count_udp(server_ip, server_port, number_input);
+                                break;
+                        }
                         return 0;
                 }        
         }


### PR DESCRIPTION
Modified files are in _adv-net-samples/sockets/latency_

Added tracking of dropped packets for both TCP and UDP.  Packets can be dropped either going to the server are be dropped from the server.  Default timeout is 500000 microseconds as defined by a text macro in _adv-net-samples/sockets/latency/latency-count.c_

To compile
`make`

To run server in tcp mode
`./latency-count -m server -p 1234 -s tcp`

To run client in tcp mode
`./latency-count -m client -h servers_address -p 1234 -n 1000 -s tcp`

To run in udp mode simply change the protocol on both the server and the client
`./latency-count -m client -h servers_address -p 1234 -n 1000 -s udp`

Tested locally by using the included local test defined in the make file
`make test_tcp`
`make test_udp`

Tested on a separate physical server connected by a spotty bluetooth tether via my phone in a cafe with packets dropped.

```
$ ./latency-count -m client -h akorzan.com -p 1234 -n 1000 -s tcp
LatencyCount[6851] works on client mode!
        Remote Server IP  : akorzan.com
        Remote Server Port: 1234
        Connecting Times  : 1000
        Client's Protocol : TCP
Result:
        The total number of loops   : 1000
        The min time of latency     : 3 us
        The max time of latency     : 469791 us
        The average time of latency : 43705.296488 us
        Number of Packets Dropped   : 32
```
