### PR TITLE
Issue #47 lossy counter bug fix

### DIFF
--- a/datastructs/counters/lossy_counter/Makefile
+++ b/datastructs/counters/lossy_counter/Makefile
@@ -1,11 +1,11 @@
 #Use the gcc compiler
 CC=gcc
-CFLAGS=-std=c99 -pedantic -Wall
+CFLAGS=-lm
+LDFLAGS=-lm
 RM=rm
 
 #List of dependency files needed for compilation
 DEPS=zipfgen.c lossycon.c lossy_test.c
-LDFLAGS=
 OBJS=zipfgen.o lossycon.o lossy_test.o
 TARGET=lossy_test
 
@@ -14,10 +14,10 @@ default:all
 all:$(TARGET)
 
 $(TARGET):$(OBJS)
-	$(CC) -o $(TARGET) $(OBJS)
+	$(CC) -o $(TARGET) $(OBJS) $(LDFLAGS)
 
 $(OBJS): $(DEPS)
-	$(CC) -c $(DEPS)
+	$(CC) -c $(DEPS) $(CFLAGS)
 
 clean:
 	$(RM) $(OBJS) $(TARGET)

--- a/datastructs/counters/lossy_counter/lossy_test.c
+++ b/datastructs/counters/lossy_counter/lossy_test.c
@@ -24,12 +24,24 @@
         http://www.gnu.org/software/libc/manual/html_node/Handler-Returns.html#Handler-Returns
 ****************************************/
 
+#define ZIPF_MAP_SIZE 100000
+
 int _running = 1;
+int zipf_map[ZIPF_MAP_SIZE];
 
 void timeout(int sig) {
         _running = 0;
         signal(sig, timeout);
 }
+
+void init_zipfmap(double alpha, int N) {
+	int i;
+	
+	srand(time(NULL));
+	for (i = 0; i < ZIPF_MAP_SIZE; i++) {
+		zipf_map[i]= get_zipf_key(alpha, N);
+	}
+};
 
 //show result and free memory
 void show_result(Counter *result) {
@@ -72,7 +84,7 @@ void counter_test(char *lossy_phi, char *zipf_N, char *zipf_alpha,
         T = atoi(runs);
         L = atoll(loops);
         if (L > 0) T = 0;
-        
+	init_zipfmap(alpha, N);
         if (T > 0) {
                 signal(SIGALRM, timeout);
                 toset.it_interval.tv_usec = 0;
@@ -86,7 +98,7 @@ void counter_test(char *lossy_phi, char *zipf_N, char *zipf_alpha,
 
         while(_running == 1) {
                 count++;
-                key = get_zipf_key(alpha, N); 
+		key = zipf_map[count % ZIPF_MAP_SIZE]; 
                 LC_Update(lcounter, key);
                 if (R > 0 && count % R == 0) {
                         if (result != NULL) {


### PR DESCRIPTION
As the reason of low speed is addressed, there is a new test result of lossy counter(old library).

$ ./lossy_test -l 10000000 -r 0 -v
Item            Count
1               64850  
2               16538  
4               1  
8               1  
117             1  
147             1  
186             1  
196             1  
Lossy speed tester parameters:
        Lossy phi :     0.010000
        zipf N :        1000
        zipf alpha :    0.500000
        running time :  1.006374
        output period : 0
        total count:    10000000
        counts per sec: 9936658.768679

It is very fast, nearly 10M/s.

This test also shows that the old library is faster than the new hash table one.

I think the reason is that the lossy counting algorithm need one loop to reduce count value in each bucket. If the loop is unavoidable, the array is faster than the hash table.
#47

@twood02 @zhangwei1984 
